### PR TITLE
fix: 라이프 초기화 되지 않던 오류 수정

### DIFF
--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -21,6 +21,7 @@ export const DEFAULT_USER_CONFIG: UserConfig = {
   life: {
     lifeCount: 3,
   },
+  time: new Date(),
 };
 
 export const LOCAL_STORAGE = Object.freeze({

--- a/src/modules/StoreController.ts
+++ b/src/modules/StoreController.ts
@@ -1,4 +1,3 @@
-import { LocalStorage } from '@src/modules/LocalStorage';
 import { UserConfig } from '@src/types';
 import { LOCAL_STORAGE, DEFAULT_USER_CONFIG } from '@src/constants';
 import { ChromeStorage } from './ChromeStorage';
@@ -11,13 +10,15 @@ export class StorageController {
   constructor(private storage: ChromeStorage) {}
 
   async getUserConfig(): Promise<UserConfig> {
-    const userConfig = await this.storage.get(LOCAL_STORAGE.KEY.USER_CONFIG);
+    const userConfig = (await this.storage.get(
+      LOCAL_STORAGE.KEY.USER_CONFIG
+    )) as UserConfig;
 
     if (userConfig === null) {
       this.storage.set(LOCAL_STORAGE.KEY.USER_CONFIG, DEFAULT_USER_CONFIG);
       return DEFAULT_USER_CONFIG;
     }
-    return this.storage.get(LOCAL_STORAGE.KEY.USER_CONFIG);
+    return userConfig;
   }
 
   /* Tags */
@@ -55,7 +56,7 @@ export class StorageController {
       question: { interval },
     } = await this.getUserConfig();
 
-    return interval || DEFAULT_USER_CONFIG.question.interval;
+    return interval;
   }
 
   /* Trigger */
@@ -97,6 +98,21 @@ export class StorageController {
       life: { ...userConfig.life, lifeCount: newLifeCount },
     };
 
+    this.storage.set(LOCAL_STORAGE.KEY.USER_CONFIG, newUserConfig);
+  }
+
+  /** Time */
+  async getTime(): Promise<Date> {
+    const { time } = await this.getUserConfig();
+    return time;
+  }
+
+  async setTime(newStartTime: Date) {
+    const userConfig = await this.getUserConfig();
+    const newUserConfig = {
+      ...userConfig,
+      time: newStartTime,
+    };
     this.storage.set(LOCAL_STORAGE.KEY.USER_CONFIG, newUserConfig);
   }
 }

--- a/src/modules/StoreController.ts
+++ b/src/modules/StoreController.ts
@@ -18,6 +18,7 @@ export class StorageController {
       this.storage.set(LOCAL_STORAGE.KEY.USER_CONFIG, DEFAULT_USER_CONFIG);
       return DEFAULT_USER_CONFIG;
     }
+
     return userConfig;
   }
 
@@ -104,6 +105,7 @@ export class StorageController {
   /** Time */
   async getTime(): Promise<Date> {
     const { time } = await this.getUserConfig();
+
     return time;
   }
 
@@ -113,6 +115,7 @@ export class StorageController {
       ...userConfig,
       time: newStartTime,
     };
+
     this.storage.set(LOCAL_STORAGE.KEY.USER_CONFIG, newUserConfig);
   }
 }

--- a/src/pages/content/components/ContentLayer.tsx
+++ b/src/pages/content/components/ContentLayer.tsx
@@ -1,16 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { styled } from 'styled-components';
 import useTimer from '../hooks/useTimer';
 import useUserAnswer from '../hooks/useUserAnswer';
-import type { Question as QuestionType } from '../types/question';
-import { getFilteredQuestion } from '../utils/question';
 import Answer from './Answer';
 import Button from './Button';
 import Question from './Question';
-import { storageController } from '@root/src/modules/StoreController';
 import useToast from '@root/src/shared/ui/toast/useToast';
 import Description from './Description';
-import { useGETQuestionQuery } from '@root/src/shared/api/question';
+import useQuestion from '../hooks/useQuestion';
 
 interface ContentLayerProps {
   lifeCount: number;
@@ -24,7 +21,18 @@ const ContentLayer = ({
   closeModal,
 }: ContentLayerProps) => {
   const { fireToast } = useToast();
-  const { data: QuestionsData } = useGETQuestionQuery();
+  const { question } = useQuestion();
+
+  const {
+    isCorrect,
+    answer,
+    isSubmitted,
+    handleChange,
+    resetAnswer,
+    setSubmitted,
+  } = useUserAnswer({
+    question,
+  });
 
   // 타이머
   const { formattedTime, start, isActive } = useTimer(60 * 5);
@@ -32,43 +40,6 @@ const ContentLayer = ({
     start();
   }, []);
 
-  // 1. 문제 랜덤으로 가져오기
-  const [question, setQuestion] = useState<QuestionType | null>(null);
-  const [isSubmitted, setIsSubmitted] = useState(false);
-
-  // 1-1. popup의 option 메시지로 받아와 tag update. 다만, state는 휘발성 메모리이기 때문에 추후 localStorage 써야 할 듯
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
-
-  useEffect(() => {
-    const messageListener = (message: any) => {
-      if (message.message === 'SELECTED_TAGS_UPDATE') {
-        setSelectedTags(message.tags);
-        storageController.setUserTags(message.tags);
-      }
-    };
-
-    chrome.runtime.onMessage.addListener(messageListener);
-
-    return () => {
-      chrome.runtime.onMessage.removeListener(messageListener);
-    };
-  }, []);
-
-  useEffect(() => {
-    try {
-      setQuestion(getFilteredQuestion(selectedTags, QuestionsData ?? []));
-      setIsSubmitted(false);
-    } catch (error) {
-      console.error(error);
-    }
-  }, [selectedTags, QuestionsData]);
-
-  // 2. 사용자 정답 작성 및 확인
-  const { isCorrect, answer, handleChange, resetAnswer } = useUserAnswer({
-    question,
-  });
-
-  // 3. 사용자 라이프 감소
   const handleSubmit = () => {
     // 입력값이 없을 경우
     if (!answer) {
@@ -76,9 +47,7 @@ const ContentLayer = ({
       return;
     }
     // 정답일 경우
-    if (isCorrect) {
-      fireToast({ message: '정답입니다!' });
-    }
+    if (isCorrect) fireToast({ message: '정답입니다!' });
     // 오답일 경우
     if (!isCorrect) {
       fireToast({ message: '오답입니다!', mode: 'DELETE' });
@@ -88,7 +57,7 @@ const ContentLayer = ({
       decreaseLifeCount();
     }
     resetAnswer();
-    setIsSubmitted(true);
+    setSubmitted();
   };
 
   useEffect(() => {
@@ -96,7 +65,7 @@ const ContentLayer = ({
       fireToast({ message: '시간이 초과되었습니다!', mode: 'ERROR' });
       decreaseLifeCount();
       resetAnswer();
-      setIsSubmitted(true);
+      setSubmitted();
     }
   }, [isActive]);
 

--- a/src/pages/content/components/Portal/Portal.tsx
+++ b/src/pages/content/components/Portal/Portal.tsx
@@ -1,45 +1,21 @@
-import { useEffect, useState } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { darkTheme } from '../../utils/theme';
 import ContentLayer from '../ContentLayer';
 import ToastList from '@root/src/shared/ui/toast/ToastList';
 import useTrigger from '../../hooks/useTrigger';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { storageController } from '@root/src/modules/StoreController';
-import { INTERVAL } from '@root/src/constants';
+import useInterval from '../../hooks/useInterval';
+
+const queryClient = new QueryClient();
 
 export default function Portal() {
-  const queryClient = new QueryClient();
-
-  const [intervalTime, setIntervalState] = useState<number>(INTERVAL.DEFAULT);
-
-  useEffect(() => {
-    (async () => {
-      const intervalTime = await storageController.getPortalIntervalTime();
-      if (intervalTime) {
-        setIntervalState(intervalTime || INTERVAL.DEFAULT);
-      }
-    })();
-  }, []);
+  const { intervalTime } = useInterval();
 
   const { Modal, isOpen, lifeCount, closeModal, decreaseLifeCount } =
     useTrigger({
       time: intervalTime,
     });
 
-  useEffect(() => {
-    const messageListener = (message: any) => {
-      if (message.message === 'UPDATE_INTERVAL') {
-        setIntervalState(message.interval);
-        storageController.setPortalIntervalTime(message.interval);
-      }
-    };
-    chrome.runtime.onMessage.addListener(messageListener);
-
-    return () => {
-      chrome.runtime.onMessage.removeListener(messageListener);
-    };
-  }, []);
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={darkTheme}>

--- a/src/pages/content/hooks/useInterval.ts
+++ b/src/pages/content/hooks/useInterval.ts
@@ -23,7 +23,9 @@ const useInterval = () => {
         storageController.setPortalIntervalTime(message.interval);
       }
     };
+
     chrome.runtime.onMessage.addListener(messageListener);
+
     return () => {
       chrome.runtime.onMessage.removeListener(messageListener);
     };

--- a/src/pages/content/hooks/useInterval.ts
+++ b/src/pages/content/hooks/useInterval.ts
@@ -1,0 +1,37 @@
+'use client';
+import { INTERVAL } from '@root/src/constants';
+import { storageController } from '@root/src/modules/StoreController';
+import { useEffect, useState } from 'react';
+
+export interface TM_FILENAME_BASEProps {}
+
+const useInterval = () => {
+  const [intervalTime, setIntervalState] = useState<number>(INTERVAL.DEFAULT);
+
+  useEffect(() => {
+    (async () => {
+      const intervalTime =
+        (await storageController.getPortalIntervalTime()) ?? INTERVAL.DEFAULT;
+      intervalTime && setIntervalState(intervalTime);
+    })();
+  }, []);
+
+  useEffect(() => {
+    const messageListener = (message: any) => {
+      if (message.message === 'UPDATE_INTERVAL') {
+        setIntervalState(message.interval);
+        storageController.setPortalIntervalTime(message.interval);
+      }
+    };
+    chrome.runtime.onMessage.addListener(messageListener);
+    return () => {
+      chrome.runtime.onMessage.removeListener(messageListener);
+    };
+  }, []);
+
+  return {
+    intervalTime,
+  };
+};
+
+export default useInterval;

--- a/src/pages/content/hooks/useInterval.ts
+++ b/src/pages/content/hooks/useInterval.ts
@@ -11,8 +11,8 @@ const useInterval = () => {
   useEffect(() => {
     (async () => {
       const intervalTime =
-        (await storageController.getPortalIntervalTime()) ?? INTERVAL.DEFAULT;
-      intervalTime && setIntervalState(intervalTime);
+        (await storageController.getPortalIntervalTime()) || INTERVAL.DEFAULT;
+      setIntervalState(intervalTime);
     })();
   }, []);
 

--- a/src/pages/content/hooks/useQuestion.ts
+++ b/src/pages/content/hooks/useQuestion.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import type { Question as QuestionType } from '../types/question';
+import { getFilteredQuestion } from '../utils/question';
+import useTags from './useTags';
+import { useGETQuestionQuery } from '@root/src/shared/api/question';
+
+const useQuestion = () => {
+  const { data: QuestionsData } = useGETQuestionQuery();
+  const [question, setQuestion] = useState<QuestionType | null>(null);
+  const { selectedTags } = useTags();
+
+  useEffect(() => {
+    try {
+      if (!QuestionsData?.length || !selectedTags?.length) return;
+      setQuestion(getFilteredQuestion(selectedTags, QuestionsData));
+    } catch (error) {
+      console.error(error);
+    }
+  }, [selectedTags, QuestionsData]);
+
+  return { question };
+};
+
+export default useQuestion;

--- a/src/pages/content/hooks/useTags.ts
+++ b/src/pages/content/hooks/useTags.ts
@@ -1,0 +1,35 @@
+import { QUESTION_TAGS } from '@root/src/constants';
+import { storageController } from '@root/src/modules/StoreController';
+import { useEffect, useState } from 'react';
+
+const useTags = () => {
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const tags = (await storageController.getUserTags()) ?? QUESTION_TAGS;
+      setSelectedTags(tags);
+    })();
+  }, []);
+
+  useEffect(() => {
+    const messageListener = (message: any) => {
+      if (message.message === 'SELECTED_TAGS_UPDATE') {
+        setSelectedTags(message.tags);
+        storageController.setUserTags(message.tags);
+      }
+    };
+
+    chrome.runtime.onMessage.addListener(messageListener);
+
+    return () => {
+      chrome.runtime.onMessage.removeListener(messageListener);
+    };
+  }, []);
+
+  return {
+    selectedTags,
+  };
+};
+
+export default useTags;

--- a/src/pages/content/hooks/useTrigger.ts
+++ b/src/pages/content/hooks/useTrigger.ts
@@ -57,7 +57,13 @@ const useTrigger = ({ time }: TriggerProps) => {
   // 1. 라이프 카운트 초기화
   useEffect(() => {
     (async () => {
-      const lifeCount = await storageController.getLifeCount();
+      const time = await storageController.getTime();
+      let lifeCount = await storageController.getLifeCount();
+      // NOTE : 어제의 시간이면 라이프 카운트 초기화
+      if (time && new Date(time).getDate() !== new Date().getDate()) {
+        storageController.setLifeCount(3);
+        lifeCount = 3;
+      }
       dispatch({ type: 'SET_LIFE_COUNT', action: lifeCount });
     })();
   }, []);
@@ -94,6 +100,7 @@ const useTrigger = ({ time }: TriggerProps) => {
     await storageController.setTriggerStatus(false);
     reset();
     _closeModal();
+    await storageController.setTime(new Date());
   };
 
   // 4. 라이프 차감

--- a/src/pages/content/hooks/useUserAnswer.ts
+++ b/src/pages/content/hooks/useUserAnswer.ts
@@ -8,6 +8,9 @@ interface UseUserAnswerReturn {
     e: ChangeEvent<HTMLTextAreaElement> | ChangeEvent<HTMLInputElement>
   ) => void;
   resetAnswer: () => void;
+  isSubmitted: boolean;
+  setSubmitted: () => void;
+  resetSubmitted: () => void;
 }
 
 interface UseUserAnswerProps {
@@ -38,11 +41,24 @@ const useUserAnswer = ({
     setAnswer('');
   };
 
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const setSubmitted = () => {
+    setIsSubmitted(true);
+  };
+
+  const resetSubmitted = () => {
+    setIsSubmitted(false);
+  };
+
   return {
     answer,
     isCorrect,
+    isSubmitted,
     handleChange,
     resetAnswer,
+    setSubmitted,
+    resetSubmitted,
   };
 };
 

--- a/src/pages/content/utils/question.ts
+++ b/src/pages/content/utils/question.ts
@@ -10,16 +10,14 @@ export const getFilteredQuestion = (
   selectedTags: string[],
   questions: Questions
 ): Question => {
-  const filteredQuestions = questions?.filter(
-    (question) =>
-      selectedTags.length === 0 ||
-      selectedTags.some((tag) => question.tags.includes(tag))
+  const filteredQuestions = questions?.filter((question) =>
+    question.tags.some((tag) => selectedTags.includes(tag))
   );
 
-  // if (filteredQuestions?.length === 0)
-  //   throw new Error(MESSAGE.ERROR.QUESTION_NOT_FOUND);
+  if (filteredQuestions?.length === 0)
+    throw new Error(MESSAGE.ERROR.QUESTION_NOT_FOUND);
 
-  const randomIndex = Math.floor(Math.random() * filteredQuestions.length);
+  const randomIndex = Math.floor(Math.random() * filteredQuestions?.length);
 
   return filteredQuestions[randomIndex];
 };

--- a/src/pages/popup/components/Tag/Tags.tsx
+++ b/src/pages/popup/components/Tag/Tags.tsx
@@ -2,6 +2,7 @@ import { Tag } from '@root/src/pages/popup/components';
 import styled from 'styled-components';
 import { storageController } from '@root/src/modules/StoreController';
 import { useEffect, useState } from 'react';
+import { QUESTION_TAGS } from '@root/src/constants';
 
 export const Tags = () => {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -18,7 +19,6 @@ export const Tags = () => {
       const newTag = prevTags.includes(tag)
         ? prevTags.filter((t) => t !== tag)
         : [...prevTags, tag];
-
       if (newTag.length === 0) return prevTags;
 
       storageController.setUserTags(newTag);
@@ -39,7 +39,7 @@ export const Tags = () => {
     <Wrapper>
       <Title>Tags</Title>
       <TagList>
-        {['DB', 'Network', 'Java', 'CS', 'DS', 'OS'].map((tag) => (
+        {QUESTION_TAGS.map((tag) => (
           <Tag
             tag={tag}
             selectedTags={selectedTags}

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -3,6 +3,7 @@ export interface UserConfig {
   question: QuestionConfig;
   trigger: TriggerConfig;
   life: LifeConfig;
+  time: Date;
 }
 
 export type QuestionConfig = {


### PR DESCRIPTION
## 📖 개요

- resolve : #33

## 💻 작업사항

1. 하루가 지나도 라이프 초기화 되지 않던 오류 수정

## 💡 작성한 이슈 외에 작업한 사항

1. 기존 태그가 저장된 태그를 불러오지 않던 오류 수정
- 기존의 코드는 팝업 창이 열리기전에 유저가 설정한 태그가 저장되지 않음
2. 기존 코드 리펙토링
- tag, interval, question 커스텀 훅 생성

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
